### PR TITLE
If allowMismatch is true, then don't reset the input when blurring.

### DIFF
--- a/jquery.flexselect.js
+++ b/jquery.flexselect.js
@@ -100,7 +100,7 @@
       this.input.blur(function() {
         if (!self.dropdownMouseover) {
           self.hide();
-          if (!self.picked) self.reset();
+          if (!this.settings.allowMismatch && !self.picked) self.reset();
         }
       });
 


### PR DESCRIPTION
If allowMismatch is true, then the input field shouldn't be reset when the user blurs out of it (i.e., it should act more like a text field).
