### PR TITLE
Added "allowMismatchBlank" configuration option.

### DIFF
--- a/jquery.flexselect.js
+++ b/jquery.flexselect.js
@@ -241,13 +241,19 @@
     },
 
     markSelected: function(n) {
-      if (n > this.results.length) return;
+      if (n < 0 || n >= this.results.length) return;
 
       var rows = this.dropdown.find("li");
       rows.removeClass(this.settings.selectedClass);
       this.selectedIndex = n;
 
-      if (n >= 0) $(rows[n]).addClass(this.settings.selectedClass);
+      var row = $(rows[n]).addClass(this.settings.selectedClass);
+      var top = row.position().top;
+      var delta = top + row.outerHeight() - this.dropdown.height();
+      if (delta > 0)
+        this.dropdown.scrollTop(this.dropdown.scrollTop() + delta);
+      else if (top < 0)
+        this.dropdown.scrollTop(Math.max(0, this.dropdown.scrollTop() + top));
     },
 
     pickSelected: function() {


### PR DESCRIPTION
The allowMismatchBlank will allow a mismatch only if the value is blank. 

This is useful for forms where the flexselect element will remain visible after submission or for re-displaying a form with a user's selected choice.

For example:
1) A flexselect for the field [ Occupation ]. 
2) User enters [ Engineer ] and submits form. 
3) User revisits page where the form displays the current selection [ Occupation ] = [ Engineer ].
4) User is no longer employed and wants to clear this value and clears/backspaces content.

Upon blur, the previous value would be set therefore preventing user from clearing.

This property is set to true by default because this is probably the most common use case. However, for fields that should never be changed (for example a "username" field), the opposite may be true and this value can be set to false.
