### PR TITLE
Event for the onselect, fired immediatly.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,20 @@ into a bad-ass autocompleting text box with flex matching support.
 
 **For more usage and examples**: [http://rmm5t.github.com/jquery-flexselect/](http://rmm5t.github.com/jquery-flexselect/)
 
+## Events:
+
+The Control Fires a Callback when a Item is selected:
+
+    <pre>
+      jQuery(document).ready(function() {
+        jQuery("select.flexselect).flexselect({
+            onselect: function(name_of_item, value_of_item) {
+              alert("You selected " + name_of_item + " with the value / id of " + value_of_item)
+            }
+          });
+      });
+    </pre>
+
 ## Inspired by:
 
 * [jQuery.quickselect](http://jonmagic.com/2008/11/12/jquery-quickselect-js) by Daniel Parker

--- a/index.html
+++ b/index.html
@@ -110,6 +110,17 @@
 jQuery(document).ready(function() {
   $("select.flexselect").flexselect();
 });</pre>
+    <p class="how">
+      Add a Event to listen for changes.
+    </p>
+      <pre>
+jQuery(document).ready(function() {
+  $("select.flexselect").flexselect({
+  onselect: function(){
+  alert("You selected " + name_of_item + " with the value / id of " + value_of_item);
+}
+});
+});</pre>
       <p class="how">
         This will turn all <tt>select</tt> elements with a class of <tt>flexselect</tt> into a flex matching masterpiece:
       </p>

--- a/jquery.flexselect.js
+++ b/jquery.flexselect.js
@@ -26,7 +26,8 @@
       dropdownClass: "flexselect_dropdown",
       inputIdTransform:    function(id)   { return id + "_flexselect"; },
       inputNameTransform:  function(name) { return; },
-      dropdownIdTransform: function(id)   { return id + "_flexselect_dropdown"; }
+      dropdownIdTransform: function(id)   { return id + "_flexselect_dropdown"; },
+      onselect: function(name, value) {}
     },
     select: null,
     input: null,
@@ -272,6 +273,11 @@
         this.input.val(selected.name);
         this.hidden.val(selected.value);
         this.picked = true;
+
+        if(this.settings.onselect) {
+          this.settings.onselect(selected.name, selected.value);
+        }
+        
       } else if (this.settings.allowMismatch) {
         this.hidden.val("");
       } else {


### PR DESCRIPTION
Hi Ryan

Thanks for the great plugin!

Was using it for a client but had a problem with the onchange event. Added the setting to for 'onselect' which passes the name and uid /id of the item.  The event is now fired immediately which is great for my situation where I have to update the page based on the selection.

Updated the docs to include the event too.

Change to suit.

Keep up the good work, Johann.
