### PR TITLE
Handle Disabled Options and Optgroups

### DIFF
--- a/flexselect.css
+++ b/flexselect.css
@@ -33,6 +33,11 @@
 	overflow: hidden;
 }
 
+.flexselect_dropdown li.disabled {
+  cursor: not-allowed;
+  color: GrayText;
+}
+
 .flexselect_selected {
 	background-color: Highlight;
 	color: HighlightText;


### PR DESCRIPTION
This handles disabled options in the original select and can either hide them from the results, or show them as an options that cannot be selected. It also checks the parent optgroup to make sure the entire group isn't disabled as well.

There is a new setting called `showDisabledOptions` that determines whether an option shows in the list as disabled, or doesn't show up at all. If you set this to `true` then the options will show up in the results as grayed out and the will not be selectable. If this is set to `false` then will never show up in the results.

The only issue is the disabled check is only run on the initial load, if an option is disabled after the initial cache has been built then it won't reflect in the results. This issue should probably be handled by a fix for #4.
