### PR TITLE
Minor bug fixes

### DIFF
--- a/jquery.flexselect.js
+++ b/jquery.flexselect.js
@@ -105,7 +105,7 @@
       this.input.focus(function() {
         self.abbreviationBeforeFocus = self.input.val();
         self.input[0].setSelectionRange(0, self.input.val().length);
-        if (!self.picked) self.filterResults();
+        if (!self.picked || self.input.val() == '') self.filterResults();
       });
 
       this.input.blur(function() {

--- a/jquery.flexselect.js
+++ b/jquery.flexselect.js
@@ -312,7 +312,7 @@
         this.setValue(selected.value);
         this.picked = true;
       } else if (this.settings.allowMismatch) {
-        this.setValue.val("");
+        this.setValue("");
       } else {
         this.reset();
       }


### PR DESCRIPTION
Line 108:
Show results if picked option is blank.
If a blank option was present, results would previously not show on focus.

Line 315:
Change `setValue.val("");` to `setValue("");`. This will now set original
`select`'s value to blank as intended.
Previously this would have no
effect and instead keep previously selected values.
Fixes issues #13 and #37.